### PR TITLE
Add digest param, default to sha1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
+  - "6.9.5"
+  - "5.12.0"
   - "4.1"
   - "4.0"
   - "0.12"
   - "0.11"
-  - "0.10"
 script: "npm test"

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var crypto = require('crypto');
 
-function RailsSessionDecoder(secret) {
+function RailsSessionDecoder(secret, digest) {
   this.secret = secret;
+  this.digest = digest || 'sha1';
   this.cookieSalt = 'encrypted cookie'; //Rails.application.config.action_dispatch.encrypted_cookie_salt
   this.signedCookieSalt = 'signed encrypted cookie'; //Rails.application.config.action_dispatch.encrypted_signed_cookie_salt
   this.iterations = 1000;
@@ -18,6 +19,10 @@ RailsSessionDecoder.prototype.decodeSignedCookie = function (cookie, next) {
 
 RailsSessionDecoder.prototype.setSecret = function(newSecret) {
   this.secret = newSecret;
+};
+
+RailsSessionDecoder.prototype.setDigest = function(newDigest) {
+  this.digest = newDigest;
 };
 
 RailsSessionDecoder.prototype.setCookieSalt = function(newCookieSalt) {
@@ -59,7 +64,7 @@ RailsSessionDecoder.prototype.decodeCookieFn = function (cookie, isSignedCookie,
   var iv = new Buffer(sessionDataSegments[1], 'base64');
   var salt = isSignedCookie ? this.signedCookieSalt : this.cookieSalt;
 
-  crypto.pbkdf2(this.secret, salt, this.iterations, this.keyLength, function(err, derivedKey) {
+  crypto.pbkdf2(this.secret, salt, this.iterations, this.keyLength, this.digest, function(err, derivedKey) {
     if (err) return next(err);
 
     try {

--- a/index.test.js
+++ b/index.test.js
@@ -5,8 +5,8 @@ var should = require('should'),
 var secret = '52541783ebfc236dc27e1d83cba2a4144b484897995bdf4d9a9977623987ee10b6e690d3c4218ebc50eccfb68f5babc3db0fcb131d3fbbce142803a03ac500db';
 var cookie = 'N0paYjIyWTNIOWgxV2VON0RCM1AvenZzQVNFeWY0elBoQkZ5SnN4OVAybXZQMEErV0VGa1luM2VmYTg4cEk0Y2paVUtMUW8xbEQyUE5VbFJ1OTZUeWJiODdYNkxZSWxvYUtiaE1ucy9LM1BMUy8yd0N0ZExZQzYzUVFsaGZ4M044MjdOdWNJYWhMbW5HOTJpY2UzQUdBPT0tLWtuWk9IWVJpakpWak5oSmZ2d2VLbWc9PQ==--d4292397f777c8f79655884b3fcc241e4bc2fcf5';
 var session = JSON.parse('{"session_id":"1cc5440b929e539280d94888629565d1","_csrf_token":"CzzmfmhiXOMfGDsL4wkUNsvgyjG7215I73e6bXX1MlQ="}');
-
-var decoder = sessionDecoder(secret);
+var digest = 'sha1';
+var decoder = sessionDecoder(secret, digest);
 
 describe('Constructor', function() {
   it('stores the secret', function() {
@@ -15,6 +15,10 @@ describe('Constructor', function() {
 });
 
 describe('Defaults', function(){
+
+  it('has the correct digest', function() {
+    decoder.digest.should.be.exactly(digest);
+  });
 
   it('has the correct cookieSalt', function() {
     decoder.cookieSalt.should.be.exactly('encrypted cookie');
@@ -90,6 +94,17 @@ describe('#setSecret', function() {
 
     decoder.secret.should.eql(newSecret);
   })
+});
+
+describe('#setDigest', function() {
+  it('updates the digest', function() {
+    var newDigest = 'sha512';
+    decoder.digest.should.eql(digest);
+
+    decoder.setDigest(newDigest);
+
+    decoder.digest.should.eql(newDigest);
+  });
 });
 
 describe('#setCookieSalt', function() {


### PR DESCRIPTION
Hi! Thanks for your work on this project.

[As of Node 6](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#crypto), `crypto.pbkdf2` requires that you explicitly pass a digest; the previously-optional param is now required.

I checked the rails docs, and the default digest algorithm used is `sha1`. So I set that as the default here.

This should be a completely transparent change to users on Node 5 and earlier, but it means Node 6+ users won't get deprecation warnings in their apps.

It also means that if users decide to use a more-secure digest (highly recommended these days, sha1 is very weak), this module can be used, by providing an override.